### PR TITLE
better U256 <> Uint<256;4> conversions

### DIFF
--- a/src/full_math.rs
+++ b/src/full_math.rs
@@ -116,7 +116,6 @@ pub fn mul_div_rounding_up(
 ) -> Result<U256, UniswapV3MathError> {
     let result = mul_div(a, b, denominator)?;
 
-    //TODO: not optimal, update this
     let a = u256_to_ruint(a);
     let b = u256_to_ruint(b);
     let denominator = u256_to_ruint(denominator);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,23 +1,21 @@
 use ethers::types::U256;
 use ruint::Uint;
 
-pub const RUINT_ZERO: ruint::Uint<256, 4> = ruint::Uint::<256, 4>::from_limbs([0_u64; 4]);
-pub const RUINT_ONE: ruint::Uint<256, 4> = ruint::Uint::<256, 4>::from_limbs([1, 0, 0, 0]);
-pub const RUINT_TWO: ruint::Uint<256, 4> = ruint::Uint::<256, 4>::from_limbs([2, 0, 0, 0]);
-pub const RUINT_THREE: ruint::Uint<256, 4> = ruint::Uint::<256, 4>::from_limbs([3, 0, 0, 0]);
-pub const RUINT_MAX_U256: ruint::Uint<256, 4> = ruint::Uint::<256, 4>::from_limbs([
+pub const RUINT_ZERO: Uint<256, 4> = Uint::ZERO;
+pub const RUINT_ONE: Uint<256, 4> = Uint::<256, 4>::from_limbs([1, 0, 0, 0]);
+pub const RUINT_TWO: Uint<256, 4> = Uint::<256, 4>::from_limbs([2, 0, 0, 0]);
+pub const RUINT_THREE: Uint<256, 4> = Uint::<256, 4>::from_limbs([3, 0, 0, 0]);
+pub const RUINT_MAX_U256: Uint<256, 4> = Uint::<256, 4>::from_limbs([
     18446744073709551615,
     18446744073709551615,
     18446744073709551615,
     18446744073709551615,
 ]);
 
-pub fn u256_to_ruint(u: U256) -> ruint::Uint<256, 4> {
-    let mut le_bytes = [0_u8; 32];
-    u.to_little_endian(&mut le_bytes);
-    ruint::Uint::from_le_bytes(le_bytes)
+pub fn u256_to_ruint(u: U256) -> Uint<256, 4> {
+    Uint::from_limbs(u.0)
 }
 
 pub fn ruint_to_u256(r: Uint<256, 4>) -> U256 {
-    U256::from_little_endian(&r.as_le_bytes())
+    U256(r.into_limbs())
 }


### PR DESCRIPTION
Both types are using LE byte order as is