### PR TITLE
perf: use trailing and leading zeros in bitmath

### DIFF
--- a/src/bit_math.rs
+++ b/src/bit_math.rs
@@ -1,125 +1,26 @@
-use std::ops::ShrAssign;
-
+use crate::error::UniswapV3MathError;
 use alloy::primitives::U256;
 
-use crate::{
-    error::UniswapV3MathError, U128_MAX, U16_MAX, U256_1, U256_15, U256_3, U32_MAX, U64_MAX, U8_MAX,
-};
-
-pub fn most_significant_bit(mut x: U256) -> Result<u8, UniswapV3MathError> {
-    let mut r = 0;
-
+pub fn most_significant_bit(x: U256) -> Result<u8, UniswapV3MathError> {
     if x.is_zero() {
         return Err(UniswapV3MathError::ZeroValue);
     }
-
-    if x >= U256::from_limbs([0, 0, 1, 0]) {
-        x.shr_assign(128);
-        r += 128;
-    }
-
-    if x >= U256::from_limbs([0, 1, 0, 0]) {
-        x.shr_assign(64);
-        r += 64;
-    }
-
-    if x >= U256::from_limbs([4294967296, 0, 0, 0]) {
-        x.shr_assign(32);
-        r += 32;
-    }
-
-    if x >= U256::from_limbs([65536, 0, 0, 0]) {
-        x.shr_assign(16);
-        r += 16;
-    }
-
-    if x >= U256::from_limbs([256, 0, 0, 0]) {
-        x.shr_assign(8);
-        r += 8;
-    }
-
-    if x >= U256::from_limbs([16, 0, 0, 0]) {
-        x.shr_assign(4);
-        r += 4;
-    }
-    if x >= U256::from_limbs([4, 0, 0, 0]) {
-        x.shr_assign(2);
-        r += 2;
-    }
-
-    if x >= U256::from_limbs([2, 0, 0, 0]) {
-        r += 1;
-    }
-
-    Ok(r)
+    Ok(255 - x.leading_zeros() as u8)
 }
 
-pub fn least_significant_bit(mut x: U256) -> Result<u8, UniswapV3MathError> {
+pub fn least_significant_bit(x: U256) -> Result<u8, UniswapV3MathError> {
     if x.is_zero() {
         return Err(UniswapV3MathError::ZeroValue);
     }
-
-    let mut r = 255;
-
-    if x & U128_MAX > U256::ZERO {
-        r -= 128;
-    } else {
-        x >>= 128;
-    }
-
-    if x & U64_MAX > U256::ZERO {
-        r -= 64;
-    } else {
-        x >>= 64;
-    }
-
-    if x & U32_MAX > U256::ZERO {
-        r -= 32;
-    } else {
-        x >>= 32;
-    }
-
-    if x & U16_MAX > U256::ZERO {
-        r -= 16;
-    } else {
-        x >>= 16;
-    }
-
-    if x & U8_MAX > U256::ZERO {
-        r -= 8;
-    } else {
-        x >>= 8;
-    }
-
-    if x & U256_15 > U256::ZERO {
-        r -= 4;
-    } else {
-        x >>= 4;
-    }
-
-    if x & U256_3 > U256::ZERO {
-        r -= 2;
-    } else {
-        x >>= 2;
-    }
-
-    if x & U256_1 > U256::ZERO {
-        r -= 1;
-    }
-
-    Ok(r)
+    Ok(x.trailing_zeros() as u8)
 }
 
 #[cfg(test)]
 mod test {
-
-    use std::str::FromStr;
-
-    use alloy::primitives::U256;
-
-    use crate::{bit_math::least_significant_bit, U256_1};
-
     use super::most_significant_bit;
+    use crate::{bit_math::least_significant_bit, U256_1};
+    use alloy::primitives::U256;
+    use std::str::FromStr;
 
     #[test]
     fn test_most_significant_bit() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,3 @@ const U256_262144: U256 = U256::from_limbs([262144, 0, 0, 0]);
 const U256_524288: U256 = U256::from_limbs([524288, 0, 0, 0]);
 
 const U256_MAX_TICK: U256 = U256::from_limbs([887272, 0, 0, 0]);
-const U128_MAX: U256 = U256::from_limbs([u64::MAX, u64::MAX, 0, 0]);
-const U64_MAX: U256 = U256::from_limbs([u64::MAX, 0, 0, 0]);
-const U32_MAX: U256 = U256::from_limbs([u32::MAX as u64, 0, 0, 0]);
-const U16_MAX: U256 = U256::from_limbs([u16::MAX as u64, 0, 0, 0]);
-const U8_MAX: U256 = U256::from_limbs([u8::MAX as u64, 0, 0, 0]);

--- a/src/tick_math.rs
+++ b/src/tick_math.rs
@@ -229,7 +229,6 @@ pub fn get_tick_at_sqrt_ratio(sqrt_price_x_96: U256) -> Result<i32, UniswapV3Mat
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy::primitives::U256;
     use std::{ops::Sub, str::FromStr};
 
     #[test]


### PR DESCRIPTION
The EVM only exposes to simple operations so libraries must resort to black magic to make more complex operations work and be performant. This doesn't map to the real world well, where we can simply use the standard library to do the hard work for us.