### PR TITLE
always fits 160 bits

### DIFF
--- a/src/sqrt_price_math.rs
+++ b/src/sqrt_price_math.rs
@@ -126,7 +126,7 @@ pub fn get_next_sqrt_price_from_amount_1_rounding_down(
             return Err(UniswapV3MathError::SqrtPriceIsLteQuotient);
         }
 
-        Ok(sqrt_price_x_96.overflowing_sub(quotient).0)
+        Ok(sqrt_price_x_96 - quotient)
     }
 }
 


### PR DESCRIPTION
I think you should not subtract with overflow, because the [repository states](https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L94) that the values are always 160 bits
